### PR TITLE
bug: users link redirects to a remote url 

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       <h2 class="project-tagline">{{ site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
-        <a href="{{ "/users" | relative_url }}" class="btn">Find Awesome First Time Users</a>
+        <a href="{{ site.baseurl }}{% link users.md %}" class="btn">Find Awesome First Time Users</a>
       {% endif %}
       {% if site.show_downloads %}
         <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       <h2 class="project-tagline">{{ site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
-        <a href="/users" class="btn">Find Awesome First Time Users</a>
+        <a href="{{ "/users" | relative_url }}" class="btn">Find Awesome First Time Users</a>
       {% endif %}
       {% if site.show_downloads %}
         <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,7 +16,7 @@
       <h2 class="project-tagline">{{ site.description | default: site.github.project_tagline }}</h2>
       {% if site.github.is_project_page %}
         <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
-        <a href="http://anupamdagar.me/awesome-first-timers/users" class="btn">Find Awesome First Time Users</a>
+        <a href="/users" class="btn">Find Awesome First Time Users</a>
       {% endif %}
       {% if site.show_downloads %}
         <a href="{{ site.github.zip_url }}" class="btn">Download .zip</a>


### PR DESCRIPTION
## Problem:
The `Find Awesome First Time Users` link is hard coded to the absolute url http://anupamdagar.me/awesome-first-timers/users
. This link is broken when serving the site locally.

## Solution:
Made the link for `Find Awesome First Time Users` a relative url.

## Related PR:
https://github.com/Anupam-dagar/awesome-first-timers/issues/57

## Demo:
https://larrybattle.github.io/awesome-first-timers/